### PR TITLE
Replace licence with original GPL

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -139,7 +139,7 @@ System Libraries, or general-purpose tools or generally available free
 programs which are used unmodified in performing those activities but
 which are not part of the work.  For example, Corresponding Source
 includes interface definition files associated with source files for
-the work, and the source code for shared vm.libraries and dynamically
+the work, and the source code for shared libraries and dynamically
 linked subprograms that the work is specifically designed to require,
 such as by intimate data communication or control flow between those
 subprograms and other parts of the work.


### PR DESCRIPTION
The previous version of the GPL in this repository contained a typo. This is a fix for that.